### PR TITLE
Add instruction on how to implement NXD

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,8 @@ This will allow users, as well as browsers and other user agents that may implem
 
 Resolve use-application-dns.net using the platform's DNS. If the result is NXDOMAIN, then there is some sort of content filtering or other policy implemented by platform DNS. If the domain returns a result, then there is not (or the DNS server has not added use-application-dns.net to its filtering lists.)
 
+Instructions for network administrators can be found [here](nxdomain-instructions.md).
+
 ## Who runs this?
 
 This domain is run by [Mozilla](https://mozilla.org), as an interim measure while an RFC is pursured through the IETF.

--- a/nxdomain-instructions.md
+++ b/nxdomain-instructions.md
@@ -1,0 +1,40 @@
+# How to implement NXDOMAIN results (for network administrators)
+
+Different nameserver implementations require different configuration
+
+## BIND
+
+Please refer to the [Knowledge Base article](https://kb.isc.org/docs/using-response-policy-zones-to-disable-mozilla-doh-by-default).
+
+## Knot Resolver
+
+Add this snippet to the configuration:
+
+```lua
+policy.add(policy.suffix(policy.DENY, {todname('use-application-dns.net.')}))
+```
+
+## PowerDNS Recursor
+
+Create a Lua script with this content:
+
+```lua
+local uadns = newDN('use-application-dns.net')
+function preresolve(dq)
+  if uadns == dq.qname then
+    dq.rcode = pdns.NXDOMAIN
+    return true
+  end
+  return false
+end
+```
+
+And load it using the [lua-dns-script](https://doc.powerdns.com/recursor/settings.html#lua-dns-script) configuration option.
+
+## Unbound
+
+Add the following to the Unbound configuration:
+
+```
+local-zone: "use-application-dns.net." always_nxdomain
+```


### PR DESCRIPTION
This PR adds instructions for network administrators to send NXDOMAIN responses for use-application-dns.net for several Open Source nameservers. Instruction are taken from [this](https://lists.dns-oarc.net/pipermail/dns-operations/2019-September/019179.html) thread on the DNS Operations mailing list.